### PR TITLE
update split handler

### DIFF
--- a/fortinet-forticasb/operations.py
+++ b/fortinet-forticasb/operations.py
@@ -81,7 +81,8 @@ def search_alerts(config, params):
         if params.get(key):
             # For list-type parameters, split by comma; otherwise use the provided value.
             if key in ['user', 'policy', 'activity', 'objectIdList', 'severity', 'status', 'idList', 'alertType', 'countryList']:
-                payload[key] = [s.strip() for s in params.get(key).split(",")]
+                payload[key] = [s.strip()
+                                for s in str(params.get(key)).split(",")]
             else:
                 payload[key] = params.get(key)
         else:


### PR DESCRIPTION
There was a bug for parameter which were integer only. Added a forced type of _str_.